### PR TITLE
feat: Implement recipe agent with image processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The application is configured through environment variables:
 -   `SLACK_ACCESS_TOKEN`: (Required) Your Slack app's Bot User OAuth Token.
 -   `SLACK_APP_TOKEN`: (Required) Your Slack app's App-Level Token for Socket Mode.
 -   `OLLAMA_HOST`: (Required) The URL of your Ollama instance.
--   **Default Ollama Model**: The bot currently uses the `qwen3:32b` model by default. This is hardcoded in `main.py`.
+-   **Default Ollama Model**: The bot currently uses the `llama4:maverick` model by default. This is hardcoded in `main.py`.
 
 ## Contributing
 Contributions are welcome! Please open an issue or submit a pull request.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,15 +28,15 @@ The following environment variables are required:
 
 The specific Large Language Model used by the bot is defined directly in the `main.py` file.
 
--   **Current Model:** The bot is currently hardcoded to use the `qwen3:32b` model.
+-   **Current Model:** The bot is currently hardcoded to use the `llama4:maverick` model.
 -   **Location in Code:** You can find this setting within the `handle_app_mention` function in `main.py`:
     ```python
     res = await client.chat(
-        model="qwen3:32b",  # <--- This line specifies the Ollama model
+        model="llama4:maverick",  # <--- This line specifies the Ollama model
         messages=_messages[thread_ts]
     )
     ```
--   **Changing the Model:** To use a different model available in your Ollama instance, you can change the string value `"qwen3:32b"` to your desired model name (e.g., `"llama3:latest"`, `"mistral:latest"`).
+-   **Changing the Model:** To use a different model available in your Ollama instance, you can change the string value `"llama4:maverick"` to your desired model name (e.g., `"llama3:latest"`, `"mistral:latest"`).
 -   **Available Models:** For a list of available models and how to download them, please refer to the [official Ollama library documentation](https://ollama.com/library).
 
 ## System Prompt

--- a/main.py
+++ b/main.py
@@ -6,6 +6,8 @@ from enum import Enum
 import asyncio
 from ollama import AsyncClient
 from collections import defaultdict
+import base64
+import aiohttp
 
 from dotenv import load_dotenv
 
@@ -30,6 +32,7 @@ class UserRole(str, Enum):
 class Message(BaseModel):
     role: UserRole = Field(..., description="The user who sent the message")
     content: str = Field(..., description="The text of the message")
+    images: list[str] | None = Field(default=None, description="A list of base64-encoded images")
 
     def __str__(self):
         return f"{self.role}: {self.content}"
@@ -57,20 +60,66 @@ async def handle_app_mention(body, say, ack):
     global _messages
     user_message = body["event"]["text"]
     thread_ts = body["event"].get("thread_ts", body["event"]["ts"])
+    # channel_id = body["event"]["channel"] # Useful for potential logging or context
+
     await ack()
+
+    is_recipe_request = "レシピ" in user_message
+
     if not _messages.get(thread_ts):
+        system_prompt_content = ""
+        if is_recipe_request:
+            system_prompt_content = "あなたはレシピ提案のエキスパートです。提供された食材の画像に基づいて、ユーザーが作れる料理のレシピを考えてください。材料と手順を明確に、markdown形式で提示してください。"
+        else:
+            system_prompt_content = "あなたは優秀なエージェントです。謙虚に振る舞いユーザーと簡潔に対話を行います。markdown形式で回答してください"
         _messages[thread_ts].append(
-            Message(role=UserRole.system, content=(
-                "あなたは優秀なエージェントです。謙虚に振る舞いユーザーと簡潔に対話を行います。markdown形式で回答してください"
-            )),
+            Message(role=UserRole.system, content=system_prompt_content),
         )
 
-    _messages[thread_ts].append(Message(role=UserRole.user, content=user_message))
+    base64_images = []
+    if is_recipe_request and body["event"].get("files"):
+        # Ensure aiohttp.ClientSession is created and closed properly.
+        # It's best to create it once if the function is called frequently,
+        # or use a context manager for a single call.
+        # For simplicity in this subtask, we'll create it per call using a context manager.
+        async with aiohttp.ClientSession() as session:
+            for file_info in body["event"]["files"]:
+                if file_info.get("mimetype", "").startswith("image/"):
+                    image_url = file_info.get("url_private_download")
+                    if image_url:
+                        try:
+                            # Slack API requires Authorization header with bot token
+                            headers = {"Authorization": f"Bearer {app.client.token}"}
+                            async with session.get(image_url, headers=headers) as resp:
+                                if resp.status == 200:
+                                    image_bytes = await resp.read()
+                                    base64_images.append(base64.b64encode(image_bytes).decode('utf-8'))
+                                else:
+                                    # Log or handle unsuccessful image download
+                                    print(f"Error downloading image: {resp.status} from {image_url}")
+                        except Exception as e:
+                            # Log or handle exception during download/encoding
+                            print(f"Exception during image processing: {e}")
+    
+    _messages[thread_ts].append(Message(role=UserRole.user, content=user_message, images=base64_images if base64_images else None))
+    
+    # Convert Message objects to dictionaries for Ollama client
+    # The ollama client expects a list of dicts.
+    # If Message Pydantic models are passed directly, the ollama library handles serialisation.
+    # Let's ensure this by passing the list of Message objects directly.
+    
+    ollama_messages = []
+    for msg in _messages[thread_ts]:
+        msg_dict = {"role": msg.role.value, "content": msg.content}
+        if msg.images: # Only include images if present
+            msg_dict["images"] = msg.images
+        ollama_messages.append(msg_dict)
+
     res = await client.chat(
-        model="qwen3:32b",
-        messages=_messages[thread_ts]
+        model="qwen3:32b", # Or your preferred model
+        messages=ollama_messages # Pass the list of dicts
     )
-    assistant_message = res.message.content.split('</think>')[-1]
+    assistant_message = res.message.get('content', '').split('</think>')[-1] # Ensure content key exists
     _messages[thread_ts].append(Message(role=UserRole.assistant, content=assistant_message))
     await send(say, assistant_message, thread_ts)
 

--- a/main.py
+++ b/main.py
@@ -4,9 +4,8 @@ from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
 from pydantic import BaseModel, Field
 from enum import Enum
 import asyncio
-from ollama import AsyncClient
+from ollama import AsyncClient, Image
 from collections import defaultdict
-import base64
 import aiohttp
 import json
 from dotenv import load_dotenv
@@ -32,12 +31,37 @@ class UserRole(str, Enum):
 class Message(BaseModel):
     role: UserRole = Field(..., description="The user who sent the message")
     content: str = Field(..., description="The text of the message")
-    images: list[str] | None = Field(default=None, description="A list of base64-encoded images")
+    images: list[Image] | None = Field(default=None, description="A list of base64-encoded images")
 
     def __str__(self):
         return f"{self.role}: {self.content}"
 
 
+async def download_and_encode_images(files, slack_client_token):
+    """
+    Downloads images from Slack file objects and encodes them in base64.
+    """
+    base64_images = []
+    async with aiohttp.ClientSession() as session:
+        for file_info in files:
+            if file_info.get("mimetype", "").startswith("image/"):
+                image_url = file_info.get("url_private_download")
+                if image_url:
+                    try:
+                        # Slack API requires Authorization header with bot token
+                        headers = {"Authorization": f"Bearer {slack_client_token}"}
+                        async with session.get(image_url, headers=headers) as resp:
+                            if resp.status == 200:
+                                image_bytes = await resp.read()
+                                if not image_bytes:
+                                    print(f"Empty image bytes for {image_url}")
+                                    continue
+                                base64_images.append(Image(value=image_bytes))
+                            else:
+                                print(f"Error downloading image: {resp.status} from {image_url}")
+                    except Exception as e:
+                        print(f"Exception during image processing: {e}")
+    return base64_images
 
 async def send(say, message: str, thread_ts):
     text = {
@@ -49,7 +73,8 @@ async def send(say, message: str, thread_ts):
                     "text": message
                 }
             },
-        ]
+        ],
+        "text": message,
     }
     await say(text, thread_ts=thread_ts)
 
@@ -58,7 +83,6 @@ _messages = defaultdict(list)
 @app.event("message")
 async def handle_app_mention(body, say, ack):
     global _messages
-    print(json.dumps(body, ensure_ascii=False, indent=2))
     await ack()
 
     user_message = body["event"].get("text", "") or body["event"].get("message", {}).get("text", "")
@@ -70,7 +94,7 @@ async def handle_app_mention(body, say, ack):
     if not _messages.get(thread_ts):
         system_prompt_content = ""
         if is_recipe_request:
-            system_prompt_content = "あなたはレシピ提案のエキスパートです。提供された食材の画像に基づいて、ユーザーが作れる料理のレシピを考えてください。材料と手順を明確に、markdown形式で提示してください。"
+            system_prompt_content = "あなたはレシピ提案のエキスパートです。提供された食材の画像に基づいて、ユーザーが作れる料理のレシピ案を3つ考えてください。材料と分量だけを明確に、markdown形式で提示してください。"
         else:
             system_prompt_content = "あなたは優秀なエージェントです。謙虚に振る舞いユーザーと簡潔に対話を行います。markdown形式で回答してください"
         _messages[thread_ts].append(
@@ -79,28 +103,7 @@ async def handle_app_mention(body, say, ack):
 
     base64_images = []
     if is_recipe_request and body["event"].get("files"):
-        # Ensure aiohttp.ClientSession is created and closed properly.
-        # It's best to create it once if the function is called frequently,
-        # or use a context manager for a single call.
-        # For simplicity in this subtask, we'll create it per call using a context manager.
-        async with aiohttp.ClientSession() as session:
-            for file_info in body["event"]["files"]:
-                if file_info.get("mimetype", "").startswith("image/"):
-                    image_url = file_info.get("url_private_download")
-                    if image_url:
-                        try:
-                            # Slack API requires Authorization header with bot token
-                            headers = {"Authorization": f"Bearer {app.client.token}"}
-                            async with session.get(image_url, headers=headers) as resp:
-                                if resp.status == 200:
-                                    image_bytes = await resp.read()
-                                    base64_images.append(base64.b64encode(image_bytes).decode('utf-8'))
-                                else:
-                                    # Log or handle unsuccessful image download
-                                    print(f"Error downloading image: {resp.status} from {image_url}")
-                        except Exception as e:
-                            # Log or handle exception during download/encoding
-                            print(f"Exception during image processing: {e}")
+        base64_images = await download_and_encode_images(body["event"]["files"], app.client.token)
     
     _messages[thread_ts].append(Message(role=UserRole.user, content=user_message, images=base64_images if base64_images else None))
     

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from ollama import AsyncClient
 from collections import defaultdict
 import base64
 import aiohttp
-
+import json
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -58,11 +58,12 @@ _messages = defaultdict(list)
 @app.event("message")
 async def handle_app_mention(body, say, ack):
     global _messages
-    user_message = body["event"]["text"]
+    print(json.dumps(body, ensure_ascii=False, indent=2))
+    await ack()
+
+    user_message = body["event"].get("text", "") or body["event"].get("message", {}).get("text", "")
     thread_ts = body["event"].get("thread_ts", body["event"]["ts"])
     # channel_id = body["event"]["channel"] # Useful for potential logging or context
-
-    await ack()
 
     is_recipe_request = "レシピ" in user_message
 
@@ -116,7 +117,7 @@ async def handle_app_mention(body, say, ack):
         ollama_messages.append(msg_dict)
 
     res = await client.chat(
-        model="qwen3:32b", # Or your preferred model
+        model="llama4:maverick", # Or your preferred model
         messages=ollama_messages # Pass the list of dicts
     )
     assistant_message = res.message.get('content', '').split('</think>')[-1] # Ensure content key exists


### PR DESCRIPTION
I've added functionality to main.py to act as a recipe-generating agent when the keyword "レシピ" (recipe) is detected in a Slack message.

Changes include:
- Modifying the Message Pydantic model to include an optional 'images' field for base64-encoded image data.
- Updating the Slack message handler:
  - Detects the "レシピ" keyword in incoming messages.
  - Switches to a specialized system prompt for recipe generation if "レシピ" is present in the first message of a thread.
  - If images are attached to a Slack message containing "レシピ":
    - Downloads the image files using their private URLs and the bot token.
    - Encodes the downloaded images in base64.
    - Includes the base64 image strings in the 'images' field of the message sent to the Ollama API.
  - Ensures that the message structure passed to the Ollama client.chat method correctly includes the role, content, and images (if any).
- Adding necessary imports (base64, aiohttp) and ensuring aiohttp is a declared dependency.

Testing:
I recommend you perform manual end-to-end testing:
1. Send a Slack message with "レシピ" and an image: verify recipe prompt and image-based recipe.
2. Send "レシピ" without image: verify recipe prompt and general recipe/query.
3. Send a normal message: verify default prompt and normal response.
4. Check logs for any errors during image download/processing.