### PR TITLE
Integrate slack_agent and search_agent via A2A protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,27 +8,29 @@ This project is a Slack bot that interacts with an Ollama-based Large Language M
 - Maintains a separate conversation history for each thread.
 - Interacts with a configurable Ollama model.
 - Responds in markdown format.
+- **Integrated Search Mode:** Offers a special `/search` mode in Slack that communicates with a dedicated `search_agent` via an A2A (Agent-to-Agent) protocol. This allows users to directly leverage the `search_agent`'s web search capabilities.
 - **Conversation Memory (Optional):** When enabled via the `MEMORY_FEATURE_ENABLED` environment variable, the bot generates a 'meeting minutes' style summary of the entire conversation within a thread. These comprehensive summaries are stored globally, with each conversation thread keeping only its latest summary (updated upon new activity in the thread). These global summaries are then used as context for new interactions.
 
 ## Search Agent
-The Search Agent is a sophisticated component capable of performing web searches, browsing URLs, reading/writing files, and executing shell commands to answer user queries or complete complex tasks. It utilizes an Ollama-based Large Language Model (LLM) for reasoning, tool selection, and task execution.
+The Search Agent is a sophisticated component that now runs as an **A2A (Agent-to-Agent) server**. It is capable of performing web searches, browsing URLs, and potentially other tasks, exposing these as services to other agents. It utilizes an Ollama-based Large Language Model (LLM) for reasoning, tool selection, and task execution when handling requests.
 
 Key features of the Search Agent include:
 - **Web Search:** Leverages the Google Custom Search API to find relevant information online.
 - **URL Browsing:** Can navigate to web pages and extract their content using Playwright.
 - **File System Operations:** Able to read from and write to files within its designated workspace.
 - **Command Execution:** Can run shell commands (with some restrictions, e.g., `curl` and `wget` are disabled by default).
-- **LLM-Powered Tool Use:** Employs an LLM (e.g., Qwen) via Ollama to intelligently choose and use available tools in a step-by-step manner to achieve user-defined objectives.
-- **Interactive Task Refinement:** Can refine tasks based on context and interact with the user for clarifications or confirmations.
+- **LLM-Powered Tool Use:** Employs an LLM (e.g., Qwen) via Ollama to intelligently choose and use available tools in a step-by-step manner to achieve objectives based on A2A requests.
+- **A2A Service:** Exposes its functionality, primarily search, via an A2A server interface (see `A2A_HOST`, `A2A_PORT` in configuration).
 
-The core logic for the Search Agent is located in the `agents/search_agent/` directory, primarily within `search_agent.py` (main agent logic) and `search_tools.py` (tool implementations).
+The core logic for the Search Agent is located in the `agents/search_agent/` directory, primarily within `search_agent.py`.
 
 ### Running the Search Agent
-The Search Agent is designed to be run as a standalone script. Ensure you have the necessary environment variables configured (see "Configuration" section).
+The Search Agent is now run as an A2A server. Ensure you have the necessary environment variables configured (see "Configuration" section, particularly A2A settings).
 To run the agent:
 ```bash
 python agents/search_agent/search_agent.py
 ```
+This starts the A2A server, making it available for agents like the `slack_agent` to connect.
 Note: The Search Agent uses Playwright for browser automation, which may require installing browser binaries the first time it runs or if they are not found. Playwright will attempt to download them automatically. The agent also uses a separate Ollama instance, configured by default to `http://localhost:12345`.
 
 ## Prerequisites
@@ -90,10 +92,14 @@ The application is configured through environment variables:
 -   `SLACK_APP_TOKEN`: (Required) Your Slack app's App-Level Token for Socket Mode.
 -   `OLLAMA_HOST`: (Required) The URL of your Ollama instance (e.g., `http://localhost:11434` for the Slack bot).
 -   `MEMORY_FEATURE_ENABLED`: (Optional) Set to `true` to enable the conversation memory feature for the Slack bot. Defaults to `false`.
--   **Default Ollama Model**: The Slack bot currently uses the `llama4:maverick` model by default. This is hardcoded in `main.py`.
+-   **Default Ollama Model**: The Slack bot currently uses the `MODEL` variable defined in `main.py` (e.g. "qwen3:32b"). This can be changed there.
 
 ### Search Agent Specific Configuration
 The following environment variables are used by the Search Agent:
+-   `A2A_HOST`: Host for the `search_agent` A2A server (default: `0.0.0.0`).
+-   `A2A_PORT`: Port for the `search_agent` A2A server (default: `8080`).
+-   `SEARCH_AGENT_A2A_HOST`: Host of the `search_agent` A2A server that `slack_agent` connects to (default: `localhost`).
+-   `SEARCH_AGENT_A2A_PORT`: Port of the `search_agent` A2A server that `slack_agent` connects to (default: `8080`).
 -   `GOOGLE_API_KEY`: (Required for Search Agent) Your Google Custom Search API Key. Used for the web search functionality.
 -   `GOOGLE_SEARCH_ENGINE_ID`: (Required for Search Agent) Your Google Custom Search Engine ID. Used for the web search functionality.
 -   `OLLAMA_HOST` (for Search Agent): The Search Agent is configured to use an Ollama instance at `http://localhost:12345` by default (see `agents/search_agent/search_agent.py`). If you need to change this, you might need to modify the script directly or adapt it to use an environment variable.

--- a/agents/slack_agent/main.py
+++ b/agents/slack_agent/main.py
@@ -328,7 +328,7 @@ async def handle_app_mention(body, say, ack):
             print(f"Search mode active for {thread_ts}. Query: {user_message}. Contacting A2A server at {SEARCH_AGENT_A2A_HOST}:{SEARCH_AGENT_A2A_PORT}")
             await client_a2a.connect()
             response_data = await client_a2a.call_method("handle_search", query=user_message)
-            
+
             if isinstance(response_data, A2AMessage):
                 search_result = response_data.content
             elif isinstance(response_data, str):

--- a/agents/slack_agent/pyproject.toml
+++ b/agents/slack_agent/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic>=2.11.4",
     "slack-bolt>=1.23.0",
     "slack-sdk",
+    "a2a-sdk",
     "multidict",
     "attrs",
     "yarl",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,38 @@ The following environment variables are required:
     -   **Example:** `MEMORY_FEATURE_ENABLED=true`
     -   **Default:** `false`
 
+## A2A Integration Configuration
+
+The system uses an Agent-to-Agent (A2A) communication protocol for certain features, such as the dedicated search functionality provided by the `search_agent`.
+
+### Search Agent (A2A Server) Configuration
+
+These variables configure the A2A server running within the `search_agent`:
+
+-   `A2A_HOST`:
+    -   **Description:** The host address the `search_agent`'s A2A server binds to. This determines on which network interface the server listens. Use `0.0.0.0` to listen on all available interfaces, or `localhost` for local connections only.
+    -   **Default:** `0.0.0.0`
+    -   **Example:** `A2A_HOST=0.0.0.0`
+
+-   `A2A_PORT`:
+    -   **Description:** The port number the `search_agent`'s A2A server listens on.
+    -   **Default:** `8080`
+    -   **Example:** `A2A_PORT=8080`
+
+### Slack Agent (A2A Client) Configuration
+
+These variables configure the `slack_agent` to connect to the `search_agent`'s A2A server:
+
+-   `SEARCH_AGENT_A2A_HOST`:
+    -   **Description:** The hostname or IP address where the `search_agent`'s A2A server is running, as seen from the `slack_agent`.
+    -   **Default:** `localhost` (assumes `search_agent` is running on the same machine)
+    -   **Example:** `SEARCH_AGENT_A2A_HOST=search-agent-service` (if running in a containerized environment with service discovery)
+
+-   `SEARCH_AGENT_A2A_PORT`:
+    -   **Description:** The port number of the `search_agent`'s A2A server that the `slack_agent` should connect to.
+    -   **Default:** `8080`
+    -   **Example:** `SEARCH_AGENT_A2A_PORT=8080`
+
 ## Ollama Model
 
 The specific Large Language Model used by the bot is defined directly in the `main.py` file.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@
 
 ## Overview
 This project is a Slack bot that interacts with an Ollama-based Large Language Model (LLM). It allows users to communicate with the LLM through Slack messages, maintaining separate conversation histories for each thread.
+It also features an integrated search capability where the Slack bot can communicate with a dedicated `search_agent` via an A2A (Agent-to-Agent) protocol to perform web searches.
 
 ## Navigation
 - [Setup](setup.md)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,6 +39,38 @@ The bot listens for messages in channels it has been added to and in direct mess
     Translation: "You are an excellent agent. Behave humbly and interact concisely with users. Please respond in markdown format."
     This means the bot will aim to be helpful, polite, concise, and will format its answers using markdown.
 
+## Slack Agent Search Mode
+
+The Slack Agent features a dedicated "Search Mode" that allows you to send queries directly to the integrated `search_agent`. This mode is useful for when you specifically need web search results or other information the `search_agent` can provide, bypassing the Slack Agent's general LLM conversational abilities for that query.
+
+**How to Use Search Mode:**
+
+1.  **Enter Search Mode:**
+    To enter search mode within a specific Slack thread, type the command:
+    ```
+    /search
+    ```
+    The bot will confirm that you have entered search mode for that thread.
+
+2.  **Send Queries:**
+    Once in search mode, any message you send in that thread will be treated as a query to the `search_agent`.
+    For example:
+    ```
+    What are the latest developments in AI?
+    ```
+    The `slack_agent` will forward this query to the `search_agent`, and the results from the `search_agent` will be posted back into the thread.
+
+3.  **Exit Search Mode:**
+    To exit search mode and return to normal conversation with the Slack Agent's LLM in that thread, type the command:
+    ```
+    /search_exit
+    ```
+    The bot will confirm that you have exited search mode. Further messages in the thread will be processed by the Slack Agent's primary LLM again.
+
+**Note:**
+- Search mode is specific to each Slack thread. You can be in search mode in one thread and in normal conversation mode in another.
+- If you send `/search` in a thread where you are already in search mode, it will effectively do nothing but might re-confirm you are in search mode. Similarly for `/search_exit`.
+
 ## Conversation Memory Feature (Optional)
 
 This bot includes an optional conversation memory feature. If enabled by the administrator (using the `MEMORY_FEATURE_ENABLED` environment variable), the bot will:

--- a/tests/requirements-dev.txt
+++ b/tests/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-asyncio

--- a/tests/test_search_agent_a2a.py
+++ b/tests/test_search_agent_a2a.py
@@ -1,0 +1,72 @@
+import asyncio
+import os
+import pytest
+from a2a.client import A2AClient
+from a2a.message import Message as A2AMessage # Assuming this might be needed, or for consistency
+
+# Configuration for the search_agent A2A server
+# These should match how the server is run, possibly from environment variables
+SEARCH_AGENT_HOST = os.getenv("A2A_HOST", "localhost") # Assuming search_agent uses A2A_HOST
+SEARCH_AGENT_PORT = int(os.getenv("A2A_PORT", "8080")) # Assuming search_agent uses A2A_PORT
+
+@pytest.mark.asyncio
+async def test_search_agent_a2a_connectivity_and_search():
+    '''
+    Tests basic A2A connection to the search_agent and a simple search query.
+    This test expects the search_agent (A2A server) to be running separately.
+    '''
+    print(f"Attempting to connect to search_agent A2A server at {SEARCH_AGENT_HOST}:{SEARCH_AGENT_PORT}")
+    client = A2AClient(remote_host=SEARCH_AGENT_HOST, remote_port=SEARCH_AGENT_PORT)
+
+    query = "test query"
+    response_content = None
+    error = None
+
+    try:
+        await client.connect()
+        assert client.is_connected(), "A2A client failed to connect to search_agent server."
+        
+        print(f"Connected. Sending search query: '{query}'")
+        # Assuming 'handle_search' is the method exposed by SearchServiceAgent
+        response_data = await client.call_method("handle_search", query=query)
+        
+        print(f"Received response_data: {type(response_data)} - {response_data}")
+
+        if isinstance(response_data, A2AMessage):
+            response_content = response_data.content
+        elif isinstance(response_data, str):
+            response_content = response_data
+        elif isinstance(response_data, dict) and 'result' in response_data:
+            response_content = response_data['result']
+        else:
+            response_content = str(response_data) # Fallback
+
+        print(f"Extracted response content: {response_content}")
+        assert response_content is not None, "Response content should not be None."
+        assert isinstance(response_content, str), "Response content should be a string."
+        # A very basic check; ideally, we'd know more about expected success/failure format
+        assert "Error performing search:" not in response_content if "Error" not in query else True
+
+    except Exception as e:
+        error = e
+        print(f"An error occurred during the A2A test: {e}")
+        import traceback
+        traceback.print_exc()
+    finally:
+        if client.is_connected():
+            await client.disconnect()
+            print("Disconnected from search_agent A2A server.")
+
+    assert error is None, f"A2A client test failed with error: {error}"
+    # If the query was not designed to cause an error, then response_content should not be empty.
+    if "Error" not in query:
+        assert response_content, "Search result content should not be empty for a valid query."
+
+# To run this test (example, assuming search_agent is running):
+# pytest tests/test_search_agent_a2a.py 
+#
+# Note: This test requires the search_agent to be running and accessible.
+# It also assumes the a2a-sdk's A2AClient API (connect, call_method, is_connected, disconnect).
+# The actual search functionality (ToolCaller, Ollama, Playwright) within search_agent
+# might have its own dependencies (like a running Ollama instance, network access for Playwright).
+# For a CI environment, these external services would need to be available or mocked.

--- a/tests/test_search_agent_a2a.py
+++ b/tests/test_search_agent_a2a.py
@@ -2,68 +2,84 @@ import asyncio
 import os
 import pytest
 from a2a.client import A2AClient
-from a2a.message import Message as A2AMessage # Assuming this might be needed, or for consistency
+from a2a.message import Message as A2AMessage
 
-# Configuration for the search_agent A2A server
-# These should match how the server is run, possibly from environment variables
-SEARCH_AGENT_HOST = os.getenv("A2A_HOST", "localhost") # Assuming search_agent uses A2A_HOST
-SEARCH_AGENT_PORT = int(os.getenv("A2A_PORT", "8080")) # Assuming search_agent uses A2A_PORT
+SEARCH_AGENT_HOST = os.getenv("A2A_HOST", "localhost")
+SEARCH_AGENT_PORT = int(os.getenv("A2A_PORT", "8080"))
 
 @pytest.mark.asyncio
-async def test_search_agent_a2a_connectivity_and_search():
+async def test_search_agent_a2a_full_loop_processing():
     '''
-    Tests basic A2A connection to the search_agent and a simple search query.
+    Tests A2A connection to the search_agent and that a query is processed
+    through the agent's main loop, returning a final response.
     This test expects the search_agent (A2A server) to be running separately.
     '''
     print(f"Attempting to connect to search_agent A2A server at {SEARCH_AGENT_HOST}:{SEARCH_AGENT_PORT}")
     client = A2AClient(remote_host=SEARCH_AGENT_HOST, remote_port=SEARCH_AGENT_PORT)
 
-    query = "test query"
+    # Use a query that the agent should be able to process and "complete".
+    # For example, a direct request for information.
+    query = "What is the capital of France?"
     response_content = None
-    error = None
+    error_during_test = None
 
     try:
         await client.connect()
         assert client.is_connected(), "A2A client failed to connect to search_agent server."
-        
-        print(f"Connected. Sending search query: '{query}'")
-        # Assuming 'handle_search' is the method exposed by SearchServiceAgent
+
+        print(f"Connected. Sending query for full processing: '{query}'")
         response_data = await client.call_method("handle_search", query=query)
-        
+
         print(f"Received response_data: {type(response_data)} - {response_data}")
 
-        if isinstance(response_data, A2AMessage):
-            response_content = response_data.content
-        elif isinstance(response_data, str):
+        # Response should be a string directly from the A2AMessenger via SearchServiceAgent.handle_search
+        if isinstance(response_data, str):
             response_content = response_data
-        elif isinstance(response_data, dict) and 'result' in response_data:
-            response_content = response_data['result']
         else:
-            response_content = str(response_data) # Fallback
+            # This case should ideally not happen if SearchServiceAgent.handle_search is implemented correctly
+            # to always return a string.
+            response_content = f"Unexpected response type: {type(response_data)}, content: {str(response_data)}"
+
 
         print(f"Extracted response content: {response_content}")
         assert response_content is not None, "Response content should not be None."
-        assert isinstance(response_content, str), "Response content should be a string."
-        # A very basic check; ideally, we'd know more about expected success/failure format
-        assert "Error performing search:" not in response_content if "Error" not in query else True
+        assert isinstance(response_content, str), f"Response content should be a string, but got {type(response_content)}."
+        assert len(response_content) > 0, "Response content should not be empty."
+
+        # Check for common error messages that might be returned if the agent loop fails correctly
+        # These indicate the agent tried to handle an issue, not that the test itself failed.
+        # For a simple query like "What is the capital of France?", we expect a successful answer.
+        assert "Error: Task is blocked waiting for user input" not in response_content, "Agent should not get stuck waiting for user in A2A."
+        assert "Error: Task processing timed out" not in response_content, "Agent task should not time out for this query."
+        assert "Error: Agent did not produce a final response" not in response_content, "Agent should produce a response."
+        assert "Error: Agent generated a null response" not in response_content, "Agent response should not be null."
+
+        # For a query like "What is the capital of France?",
+        # we might expect the word "Paris" in the response.
+        # This makes the test more specific but also more brittle if the LLM phrasing changes.
+        # Use with caution or make it a softer check.
+        # For now, let's assume a successful execution implies the agent found an answer.
+        print(f"Received final response from agent: {response_content}")
+
 
     except Exception as e:
-        error = e
+        error_during_test = e
         print(f"An error occurred during the A2A test: {e}")
         import traceback
         traceback.print_exc()
     finally:
-        if client.is_connected():
+        if client.is_connected(): # Check if client was successfully connected before trying to disconnect
             await client.disconnect()
             print("Disconnected from search_agent A2A server.")
+        elif hasattr(client, 'disconnect') and client._connection: # Fallback for cases where is_connected might be false but disconnect is needed
+             await client.disconnect()
+             print("Disconnected from search_agent A2A server (fallback).")
 
-    assert error is None, f"A2A client test failed with error: {error}"
-    # If the query was not designed to cause an error, then response_content should not be empty.
-    if "Error" not in query:
-        assert response_content, "Search result content should not be empty for a valid query."
+
+    assert error_during_test is None, f"A2A client test failed with an exception: {error_during_test}"
 
 # To run this test (example, assuming search_agent is running):
-# pytest tests/test_search_agent_a2a.py 
+# pytest tests/test_search_agent_a2a.py
 #
 # Note: This test requires the search_agent to be running and accessible.
 # It also assumes the a2a-sdk's A2AClient API (connect, call_method, is_connected, disconnect).

--- a/tests/test_slack_agent_a2a.py
+++ b/tests/test_slack_agent_a2a.py
@@ -1,0 +1,157 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock, ANY
+from collections import defaultdict
+
+# Import the functions/classes to be tested from slack_agent.main
+# This might require adjusting the Python path or how slack_agent is structured as a package.
+# For this example, let's assume we can import `handle_app_mention` and necessary globals.
+# If slack_agent.main is a script, we might need to refactor it or use more complex import methods.
+# For now, let's assume direct import is possible for testing context.
+# This often means ensuring 'agents' is in PYTHONPATH or running pytest from the root.
+
+# To make this runnable, we'll mock the slack_agent.main dependencies.
+# We need to patch them where they are looked up. If main.py uses 'from a2a.client import A2AClient',
+# we patch 'agents.slack_agent.main.A2AClient'.
+
+# Mock a subset of slack_agent.main's global state and dependencies
+# These would normally be initialized in slack_agent.main
+mock_app_client_token = "mock_slack_app_token"
+
+# Path to the module/objects we need to mock
+slack_main_path = "agents.slack_agent.main"
+
+@pytest.fixture
+def mock_slack_event_body(self):
+    def _get_event(text, thread_ts="thread1", event_ts="event1"):
+        return {
+            "event": {
+                "type": "message",
+                "text": text,
+                "user": "U123",
+                "ts": event_ts,
+                "channel": "C123",
+                "thread_ts": thread_ts,
+                "files": [] # Assuming no files for these tests
+            },
+            "client_msg_id": "some-uuid"
+        }
+    return _get_event
+
+@pytest.fixture(autouse=True)
+def mock_slack_agent_globals():
+    # Mock globals that handle_app_mention might depend on from main.py
+    # This is a simplified approach. A better way would be to refactor main.py
+    # to make its dependencies injectable or its functions more self-contained.
+    with patch(f"{slack_main_path}.SEARCH_AGENT_A2A_HOST", "testhost"),          patch(f"{slack_main_path}.SEARCH_AGENT_A2A_PORT", 1234),          patch(f"{slack_main_path}._messages", defaultdict(list)),          patch(f"{slack_main_path}._search_mode_state", defaultdict(bool)) as mock_search_state,          patch(f"{slack_main_path}.SYSTEM_PROMPT_RULES", []),          patch(f"{slack_main_path}.MEMORY_FEATURE_ENABLED", False),          patch(f"{slack_main_path}.app") as mock_app:
+        # Mock app.client.token if download_and_encode_images were to be called
+        mock_app.client.token = mock_app_client_token
+        yield mock_search_state
+
+
+@pytest.mark.asyncio
+@patch(f"{slack_main_path}.send", new_callable=AsyncMock) # Mocks the send utility in slack_agent
+@patch(f"{slack_main_path}.A2AClient") # Mocks the A2AClient class
+async def test_slack_agent_enter_search_mode(mock_a2a_client_class, mock_send_func, mock_slack_event_body, mock_slack_agent_globals):
+    from agents.slack_agent.main import handle_app_mention # Import here after mocks are set up
+
+    mock_say = AsyncMock()
+    mock_ack = AsyncMock()
+    
+    event_body = mock_slack_event_body("/search", thread_ts="t_search_enter")
+    
+    await handle_app_mention(body=event_body, say=mock_say, ack=mock_ack)
+    
+    mock_ack.assert_called_once()
+    mock_send_func.assert_called_once_with(mock_say, "Entered search mode. Send your queries. Type '/search_exit' to leave.", "t_search_enter")
+    assert mock_slack_agent_globals["t_search_enter"] is True # Check state was set
+
+@pytest.mark.asyncio
+@patch(f"{slack_main_path}.send", new_callable=AsyncMock)
+@patch(f"{slack_main_path}.A2AClient")
+async def test_slack_agent_exit_search_mode(mock_a2a_client_class, mock_send_func, mock_slack_event_body, mock_slack_agent_globals):
+    from agents.slack_agent.main import handle_app_mention
+
+    mock_say = AsyncMock()
+    mock_ack = AsyncMock()
+    
+    # Enter search mode first
+    mock_slack_agent_globals["t_search_exit"] = True
+    
+    event_body = mock_slack_event_body("/search_exit", thread_ts="t_search_exit")
+    await handle_app_mention(body=event_body, say=mock_say, ack=mock_ack)
+    
+    mock_ack.assert_called_once()
+    mock_send_func.assert_called_once_with(mock_say, "Exited search mode.", "t_search_exit")
+    assert mock_slack_agent_globals["t_search_exit"] is False
+
+@pytest.mark.asyncio
+@patch(f"{slack_main_path}.send", new_callable=AsyncMock)
+@patch(f"{slack_main_path}.A2AClient") # Mock the A2AClient class itself
+async def test_slack_agent_perform_search_a2a_call_success(mock_a2a_client_class, mock_send_func, mock_slack_event_body, mock_slack_agent_globals):
+    from agents.slack_agent.main import handle_app_mention
+    
+    # Configure the mock A2AClient instance that will be created
+    mock_a2a_client_instance = AsyncMock()
+    mock_a2a_client_instance.call_method.return_value = "Test search result" # Simulate successful string response
+    mock_a2a_client_class.return_value = mock_a2a_client_instance # A2AClient() will return our mock instance
+
+    mock_say = AsyncMock()
+    mock_ack = AsyncMock()
+    
+    thread_id = "t_search_do"
+    mock_slack_agent_globals[thread_id] = True # Set to search mode
+
+    query = "what is A2A?"
+    event_body = mock_slack_event_body(query, thread_ts=thread_id)
+    
+    await handle_app_mention(body=event_body, say=mock_say, ack=mock_ack)
+    
+    mock_ack.assert_called_once()
+    
+    # Check A2AClient instantiation and calls
+    mock_a2a_client_class.assert_called_once_with(remote_host="testhost", remote_port=1234)
+    mock_a2a_client_instance.connect.assert_called_once()
+    mock_a2a_client_instance.call_method.assert_called_once_with("handle_search", query=query)
+    mock_a2a_client_instance.disconnect.assert_called_once()
+    
+    # Check that search result is sent to Slack
+    mock_send_func.assert_called_once_with(mock_say, f"Search results:\nTest search result", thread_id)
+
+@pytest.mark.asyncio
+@patch(f"{slack_main_path}.send", new_callable=AsyncMock)
+@patch(f"{slack_main_path}.A2AClient")
+async def test_slack_agent_perform_search_a2a_call_failure(mock_a2a_client_class, mock_send_func, mock_slack_event_body, mock_slack_agent_globals):
+    from agents.slack_agent.main import handle_app_mention
+
+    mock_a2a_client_instance = AsyncMock()
+    mock_a2a_client_instance.call_method.side_effect = Exception("A2A connection error")
+    mock_a2a_client_class.return_value = mock_a2a_client_instance
+
+    mock_say = AsyncMock()
+    mock_ack = AsyncMock()
+
+    thread_id = "t_search_fail"
+    mock_slack_agent_globals[thread_id] = True # Set to search mode
+    
+    query = "search that fails"
+    event_body = mock_slack_event_body(query, thread_ts=thread_id)
+
+    await handle_app_mention(body=event_body, say=mock_say, ack=mock_ack)
+    
+    mock_ack.assert_called_once()
+    mock_a2a_client_class.assert_called_once_with(remote_host="testhost", remote_port=1234)
+    mock_a2a_client_instance.connect.assert_called_once()
+    mock_a2a_client_instance.call_method.assert_called_once_with("handle_search", query=query)
+    # disconnect should still be called in finally block
+    mock_a2a_client_instance.disconnect.assert_called_once() 
+    
+    mock_send_func.assert_called_once_with(mock_say, "Error communicating with search agent: A2A connection error", thread_id)
+
+# Note: For these tests to run, you might need to:
+# 1. Ensure the project root is in PYTHONPATH so `from agents.slack_agent.main import ...` works.
+#    (e.g., by running pytest from the root directory of the project).
+# 2. The global variables in slack_agent.main might need to be initialized or mocked appropriately
+#    if they are accessed outside of functions or are more complex. The `@mock_slack_agent_globals`
+#    fixture attempts to handle this for some key variables.
+# 3. `AsyncApp` and `AsyncSocketModeHandler` are not directly tested here, only the `handle_app_mention` logic.

--- a/tests/test_slack_agent_a2a.py
+++ b/tests/test_slack_agent_a2a.py
@@ -57,11 +57,11 @@ async def test_slack_agent_enter_search_mode(mock_a2a_client_class, mock_send_fu
 
     mock_say = AsyncMock()
     mock_ack = AsyncMock()
-    
+
     event_body = mock_slack_event_body("/search", thread_ts="t_search_enter")
-    
+
     await handle_app_mention(body=event_body, say=mock_say, ack=mock_ack)
-    
+
     mock_ack.assert_called_once()
     mock_send_func.assert_called_once_with(mock_say, "Entered search mode. Send your queries. Type '/search_exit' to leave.", "t_search_enter")
     assert mock_slack_agent_globals["t_search_enter"] is True # Check state was set
@@ -74,13 +74,13 @@ async def test_slack_agent_exit_search_mode(mock_a2a_client_class, mock_send_fun
 
     mock_say = AsyncMock()
     mock_ack = AsyncMock()
-    
+
     # Enter search mode first
     mock_slack_agent_globals["t_search_exit"] = True
-    
+
     event_body = mock_slack_event_body("/search_exit", thread_ts="t_search_exit")
     await handle_app_mention(body=event_body, say=mock_say, ack=mock_ack)
-    
+
     mock_ack.assert_called_once()
     mock_send_func.assert_called_once_with(mock_say, "Exited search mode.", "t_search_exit")
     assert mock_slack_agent_globals["t_search_exit"] is False
@@ -90,7 +90,7 @@ async def test_slack_agent_exit_search_mode(mock_a2a_client_class, mock_send_fun
 @patch(f"{slack_main_path}.A2AClient") # Mock the A2AClient class itself
 async def test_slack_agent_perform_search_a2a_call_success(mock_a2a_client_class, mock_send_func, mock_slack_event_body, mock_slack_agent_globals):
     from agents.slack_agent.main import handle_app_mention
-    
+
     # Configure the mock A2AClient instance that will be created
     mock_a2a_client_instance = AsyncMock()
     mock_a2a_client_instance.call_method.return_value = "Test search result" # Simulate successful string response
@@ -98,23 +98,23 @@ async def test_slack_agent_perform_search_a2a_call_success(mock_a2a_client_class
 
     mock_say = AsyncMock()
     mock_ack = AsyncMock()
-    
+
     thread_id = "t_search_do"
     mock_slack_agent_globals[thread_id] = True # Set to search mode
 
     query = "what is A2A?"
     event_body = mock_slack_event_body(query, thread_ts=thread_id)
-    
+
     await handle_app_mention(body=event_body, say=mock_say, ack=mock_ack)
-    
+
     mock_ack.assert_called_once()
-    
+
     # Check A2AClient instantiation and calls
     mock_a2a_client_class.assert_called_once_with(remote_host="testhost", remote_port=1234)
     mock_a2a_client_instance.connect.assert_called_once()
     mock_a2a_client_instance.call_method.assert_called_once_with("handle_search", query=query)
     mock_a2a_client_instance.disconnect.assert_called_once()
-    
+
     # Check that search result is sent to Slack
     mock_send_func.assert_called_once_with(mock_say, f"Search results:\nTest search result", thread_id)
 
@@ -133,19 +133,19 @@ async def test_slack_agent_perform_search_a2a_call_failure(mock_a2a_client_class
 
     thread_id = "t_search_fail"
     mock_slack_agent_globals[thread_id] = True # Set to search mode
-    
+
     query = "search that fails"
     event_body = mock_slack_event_body(query, thread_ts=thread_id)
 
     await handle_app_mention(body=event_body, say=mock_say, ack=mock_ack)
-    
+
     mock_ack.assert_called_once()
     mock_a2a_client_class.assert_called_once_with(remote_host="testhost", remote_port=1234)
     mock_a2a_client_instance.connect.assert_called_once()
     mock_a2a_client_instance.call_method.assert_called_once_with("handle_search", query=query)
     # disconnect should still be called in finally block
-    mock_a2a_client_instance.disconnect.assert_called_once() 
-    
+    mock_a2a_client_instance.disconnect.assert_called_once()
+
     mock_send_func.assert_called_once_with(mock_say, "Error communicating with search agent: A2A connection error", thread_id)
 
 # Note: For these tests to run, you might need to:


### PR DESCRIPTION
This change introduces an A2A (Agent-to-Agent) integration between the slack_agent and the search_agent.

Key changes:

- search_agent:
  - Modified to run as an A2A server.
  - Exposes a `handle_search` method via A2A to perform searches.
  - Dependencies (including a2a-sdk) are now listed in `agents/search_agent/requirements.txt`.
  - Configurable via `A2A_HOST` and `A2A_PORT` environment variables.

- slack_agent:
  - Modified to include an A2A client.
  - Adds a "search mode" triggered by `/search` and exited by `/search_exit`.
  - When in search mode, your messages are sent as queries to the search_agent's A2A server.
  - `a2a-sdk` added to `agents/slack_agent/pyproject.toml`.
  - Configuration for connecting to search_agent via `SEARCH_AGENT_A2A_HOST` and `SEARCH_AGENT_A2A_PORT` environment variables.

- Testing:
  - Added `tests/test_search_agent_a2a.py` for basic A2A server integration testing.
  - Added `tests/test_slack_agent_a2a.py` with mocks to test the Slack agent's search mode and A2A client logic.
  - Created `tests/requirements-dev.txt` for test dependencies.

- Documentation:
  - Updated README.md and files in the docs/ directory (configuration.md, usage.md, search_agent.md, index.md) to reflect the new functionality, architecture, and configuration options.